### PR TITLE
[Feat/#26] 스터디룸 게시글 전체조회

### DIFF
--- a/src/main/java/com/semtleapp/semtleapp/semtlestudy/controller/SemtleStudyController.java
+++ b/src/main/java/com/semtleapp/semtleapp/semtlestudy/controller/SemtleStudyController.java
@@ -38,7 +38,13 @@ public class SemtleStudyController {
 
     @ApiOperation(value = "소속 스터디룸 조회", notes = "소속 스터디룸 조회")
     @GetMapping("/belong")
-    public ApiResponse<List<GetBelongAndPostStudyResDto.BelongStudyList>> getBelongStudy(Principal principal) throws Exception{
+    public ApiResponse<List<GetBelongAndPostStudyResDto.BelongStudyList>> getBelongStudy(Principal principal) throws Exception {
         return new ApiResponse<>(semtleStudyService.getBelongStudy(principal.getName()));
+    }
+
+    @ApiOperation(value = "스터디룸 게시글 전체 조회", notes = "소속 스터디룸 게시글 전체조회")
+    @GetMapping("/posts")
+    public ApiResponse<List<GetBelongAndPostStudyResDto.StudyPostList>> getStudyPost(@RequestParam String roomName) throws Exception {
+        return new ApiResponse<>(semtleStudyService.getStudyPost(roomName));
     }
 }

--- a/src/main/java/com/semtleapp/semtleapp/semtlestudy/dto/GetBelongAndPostStudyResDto.java
+++ b/src/main/java/com/semtleapp/semtleapp/semtlestudy/dto/GetBelongAndPostStudyResDto.java
@@ -2,6 +2,8 @@ package com.semtleapp.semtleapp.semtlestudy.dto;
 
 import lombok.*;
 
+import java.time.LocalDate;
+
 public class GetBelongAndPostStudyResDto {
 
     @Getter
@@ -9,9 +11,23 @@ public class GetBelongAndPostStudyResDto {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class BelongStudyList{
+    public static class BelongStudyList {
 
         private String roomName;
+
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class StudyPostList {
+
+        private String title;
+        private String email; //원래는 닉네임이지만 임시용
+        private LocalDate createdDate;
+        private boolean isCheckFile;
 
     }
 

--- a/src/main/java/com/semtleapp/semtleapp/semtlestudy/repository/SemtleStudyPostRepository.java
+++ b/src/main/java/com/semtleapp/semtleapp/semtlestudy/repository/SemtleStudyPostRepository.java
@@ -2,6 +2,29 @@ package com.semtleapp.semtleapp.semtlestudy.repository;
 
 import com.semtleapp.semtleapp.semtlestudy.entity.SemtleStudyPost;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface SemtleStudyPostRepository extends JpaRepository<SemtleStudyPost, Long> {
+
+    @Query(value = "select s.title'title', u.email'email', s.created_date'createdDate'," +
+            "              IF((select exists(select * from photo p where p.target_id = s.post_id)),'true', 'false') 'isFileCheck'\n" +
+            "       from semtle_study s\n" +
+            "       join semtle_user u on s.user_id = u.user_id\n" +
+            "       join semtle_study_room sr on s.study_id = sr.study_id\n" +
+            "       where sr.room_name=:roomName", nativeQuery = true)
+    List<GetStudyPostList> getStudyPost(@Param("roomName") String roomName);
+
+    interface GetStudyPostList {
+
+        String getTitle();
+        String getEmail();
+        LocalDate getCreatedDate();
+        boolean getIsFileCheck();
+
+    }
+
 }

--- a/src/main/java/com/semtleapp/semtleapp/semtlestudy/repository/SemtleStudyRoomRepository.java
+++ b/src/main/java/com/semtleapp/semtleapp/semtlestudy/repository/SemtleStudyRoomRepository.java
@@ -13,9 +13,9 @@ public interface SemtleStudyRoomRepository extends JpaRepository<SemtleStudyRoom
     Optional<SemtleStudyRoom> findById(Long studyId);
 
     @Query(value = "select sr.room_name'roomName' from semtle_study_room sr join semtle_study_belong sb on sr.study_id = sb.study_id where sb.user_id=:userId",nativeQuery = true)
-    List<GetAllStudyPost> getStudyRoomList(@Param("userId") Long userId);
+    List<GetBelongStudyList> getBelongStudy(@Param("userId") Long userId);
 
-    interface GetAllStudyPost{
+    interface GetBelongStudyList{
 
         String getRoomName();
 

--- a/src/main/java/com/semtleapp/semtleapp/semtlestudy/service/SemtleStudyService.java
+++ b/src/main/java/com/semtleapp/semtleapp/semtlestudy/service/SemtleStudyService.java
@@ -12,4 +12,6 @@ public interface SemtleStudyService {
     RegisterStudyRoomResDto registerStudyRoom(String email, RegisterStudyRoomReqDto registerStudyRoomReqDto);
 
     List<GetBelongAndPostStudyResDto.BelongStudyList> getBelongStudy(String email);
+
+    List<GetBelongAndPostStudyResDto.StudyPostList> getStudyPost(String roomName);
 }

--- a/src/main/java/com/semtleapp/semtleapp/semtlestudy/service/SemtleStudyServiceImpl.java
+++ b/src/main/java/com/semtleapp/semtleapp/semtlestudy/service/SemtleStudyServiceImpl.java
@@ -55,16 +55,33 @@ public class SemtleStudyServiceImpl implements SemtleStudyService {
     @Override
     public List<GetBelongAndPostStudyResDto.BelongStudyList> getBelongStudy(String email) {
         SemtleUser semtleUser = semtleUserRepository.findByEmail(email).get();
-        List<GetBelongAndPostStudyResDto.BelongStudyList> postsList = new ArrayList<>();
-        List<SemtleStudyRoomRepository.GetAllStudyPost> posts = semtleStudyRoomRepository.getStudyRoomList(semtleUser.getUserId());
-        posts.forEach(
-                result -> postsList.add(
+        List<GetBelongAndPostStudyResDto.BelongStudyList> belongList = new ArrayList<>();
+        List<SemtleStudyRoomRepository.GetBelongStudyList> belongStudyLists = semtleStudyRoomRepository.getBelongStudy(semtleUser.getUserId());
+        belongStudyLists.forEach(
+                result -> belongList.add(
                         new GetBelongAndPostStudyResDto.BelongStudyList(
                                 result.getRoomName()
                         )
                 )
         );
-        return postsList;
+        return belongList;
+    }
+
+    @Override
+    public List<GetBelongAndPostStudyResDto.StudyPostList> getStudyPost(String roomName) {
+        List<GetBelongAndPostStudyResDto.StudyPostList> postList = new ArrayList<>();
+        List<SemtleStudyPostRepository.GetStudyPostList> studyPostLists = semtleStudyPostRepository.getStudyPost(roomName);
+        studyPostLists.forEach(
+                result -> postList.add(
+                        new GetBelongAndPostStudyResDto.StudyPostList(
+                                result.getTitle(),
+                                result.getEmail(),
+                                result.getCreatedDate(),
+                                result.getIsFileCheck()
+                        )
+                )
+        );
+        return postList;
     }
 
     private void uploadPhotos(List<MultipartFile> files, SemtleStudyPost saveSemtleStudyPost) {

--- a/src/main/java/com/semtleapp/semtleapp/semtleuser/dto/SemtleUserReq.java
+++ b/src/main/java/com/semtleapp/semtleapp/semtleuser/dto/SemtleUserReq.java
@@ -11,7 +11,7 @@ public class SemtleUserReq {
     @AllArgsConstructor
     @Getter
     @Setter
-    public class Login {
+    public static class Login {
         private String email;
         //private String role;
         private String password;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->

### ✨ PR 타이틀 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 --> 
- #26 
### 🗓️ PR 날짜 🗓️
<!-- YYYY/NN/DD -->
- 2023/07/18

### ❓ 변경 사항 ❓
<!-- 내용을 적어주세요 -->


### 🧐 구현 방법 🧐
<!-- 내용을 적어주세요 -->
-  네이티브쿼리사용
- userId를 사용하여 스터디그룹 조회 api(#23 )를 미리 하여 그룹들을 얻어와 해당 그룹명을 QueryParam을 이용하여 그룹명을 통해 해당 그룹 게시글 전체조회를 할수있음 따라서 별다른 예외처리를 하지않음(다른스터디그룹이 화면에 보이지 않을 예정이끼 때문)

### 참고
포스트맨 data에 있는 email은 추후 nickName으로 변경될 예정


### 📸 API 명세서 사진 📸
<!-- 사진 첨부 -->
![image](https://github.com/SemtleApp/SERVER/assets/88827805/4e5883a0-3e81-48df-9e85-2bae606e9bf4)

```
<!-- API 링크 붙여넣기 -->
http://localhost:9000/study/posts?roomName=자바1스터디
```


